### PR TITLE
frix $ error on website

### DIFF
--- a/program.markdown
+++ b/program.markdown
@@ -106,7 +106,7 @@ eGeo <- newE hg3d [
     ]
     
 -- rotate cube
-rotateCube eGeo = forever $ do
+rotateCube eGeo = forever \$ do
                       updateC eGeo ctOrientation (\u -> (rotU vec3Z 0.02) .*. u)
                       sleepFor (msecT 12)
 ```

--- a/program.markdown
+++ b/program.markdown
@@ -106,9 +106,12 @@ eGeo <- newE hg3d [
     ]
     
 -- rotate cube
-rotateCube eGeo = forever \$ do
-                      updateC eGeo ctOrientation (\u -> (rotU vec3Z 0.02) .*. u)
-                      sleepFor (msecT 12)
+rotateCube eGeo = do
+    let loop = do
+        updateC eGeo ctOrientation (\u -> (rotU vec3Z 0.02) .*. u)
+        sleepFor (msecT 12)
+        loop
+    loop
 ```
 
 To not oversell: no there are no big games programmed with HGamer3D, yet and yes, the demo is still a "toy" example. But it is a fully functional example with sound, input, graphics, gui and gameplay.


### PR DESCRIPTION
Dear All,

somehow the $ sign in the haskell text corrupted the website (see current abstracts). I removed it.

regards
Peter
